### PR TITLE
Support i64 capacities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ categories = ["algorithms"]
 license = "MIT"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0.79"

--- a/bindings.cpp
+++ b/bindings.cpp
@@ -37,7 +37,7 @@ Int network_simplex_mcmf(Int num_vertices, Int num_edges, const Int* node_supply
     for (Int i = 0; i < num_edges; i++) {
         costs[arcs[i]] = edge_cost[i];
     }
-    NetworkSimplex<SmartDigraph> ns(G);
+    NetworkSimplex<SmartDigraph, int64_t, int64_t> ns(G);
     ns.supplyMap(supplies).upperMap(capacities).costMap(costs);
     ns.run();
     for (Int i = 0; i < num_edges; i++) {

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,5 @@
-extern crate gcc;
-
 fn main() {
-    let mut config = gcc::Build::new();
+    let mut config = cc::Build::new();
     config.opt_level(3);
     config.cpp(true);
     config.file("bindings.cpp");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ impl Graph {
     pub fn mcmf(&mut self) -> i64 {
         let num_vertices = self.nodes.len();
         let num_edges = self.edges.len();
-        let node_supply: Vec<_> = self.nodes.iter().map(|x| clamp_to_i32(x.supply)).collect();
+        let node_supply: Vec<_> = self.nodes.iter().map(|x| x.supply).collect();
         let edge_a: Vec<_> = self
             .edges
             .iter()
@@ -162,13 +162,6 @@ impl Graph {
         }
         result
     }
-}
-
-fn clamp_to_i32(x: i64) -> i64 {
-    let limit = std::i32::MAX.into();
-    let x = std::cmp::min(x, limit);
-
-    std::cmp::max(x, -limit)
 }
 
 /// This class represents a vertex in a graph.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ where
 pub struct Flow<T: Clone + Ord> {
     pub a: Vertex<T>,
     pub b: Vertex<T>,
-    pub amount: u32,
+    pub amount: u64,
     pub cost: i32,
 }
 
@@ -235,7 +235,7 @@ where
     }
 
     /// Returns the amount of flow in the path.
-    pub fn amount(&self) -> u32 {
+    pub fn amount(&self) -> u64 {
         self.flows[0].amount
     }
 
@@ -370,7 +370,7 @@ where
             .map(|x| {
                 let a = (**inverse_mapping.get(&x.a.0).unwrap()).clone();
                 let b = (**inverse_mapping.get(&x.b.0).unwrap()).clone();
-                let amount = x.data.flow as u32;
+                let amount = x.data.flow as u64;
                 let cost = x.data.cost as i32;
                 Flow { a, b, amount, cost }
             })
@@ -390,10 +390,10 @@ where
         fn decompose<T: Clone + Ord>(
             adj: &mut BTreeMap<Vertex<T>, Vec<Flow<T>>>,
             v: &Vertex<T>,
-            parent_amount: u32,
-        ) -> (u32, Vec<Flow<T>>) {
+            parent_amount: u64,
+        ) -> (u64, Vec<Flow<T>>) {
             if *v == Vertex::Sink {
-                (std::u32::MAX, Vec::new())
+                (std::u64::MAX, Vec::new())
             } else if adj.get(v).into_iter().all(|x| x.is_empty()) {
                 (0, Vec::new())
             } else {
@@ -414,7 +414,7 @@ where
         }
         let mut result = Vec::new();
         loop {
-            let (flow, path) = decompose(&mut adj, &Vertex::Source, std::u32::MAX);
+            let (flow, path) = decompose(&mut adj, &Vertex::Source, std::u64::MAX);
             if flow == 0 {
                 break;
             } else {


### PR DESCRIPTION
Related: #1 

This is addressing the incorrect result problem discussed in #1 when capacities exceeded i32::MAX. Also took the liberty to fix clippy warnings and replace casts with `TryFrom/Into` conversions (happy to remove unwraps and replace them with error reporting). 

Note: We cannot go beyond `i64` (e.g. to `__uint128`) due to the following bug/incompatibility -> https://github.com/rust-lang/rust/issues/54341
